### PR TITLE
implement JWT Authentication/Authorization

### DIFF
--- a/users/package.json
+++ b/users/package.json
@@ -14,6 +14,7 @@
     "dontusepostinstall": "npm run db:migrate"
   },
   "dependencies": {
+    "bcrypt": "^5.0.1",
     "body-parser": "^1.20.0",
     "cors": "^2.8.5",
     "dotenv": "^16.0.1",

--- a/users/yarn.lock
+++ b/users/yarn.lock
@@ -979,6 +979,14 @@ balanced-match@^1.0.0:
   resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+bcrypt@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/bcrypt/-/bcrypt-5.0.1.tgz#f1a2c20f208e2ccdceea4433df0c8b2c54ecdf71"
+  integrity sha512-9BTgmrhZM2t1bNuDtrtIMVSmmxZBrJ71n8Wg+YgdjHuIWYF7SjjmCPZFB+/5i/o/PIeRpwVJR3P+NrpIItUjqw==
+  dependencies:
+    "@mapbox/node-pre-gyp" "^1.0.0"
+    node-addon-api "^3.1.0"
+
 binary-extensions@^2.0.0:
   version "2.2.0"
   resolved "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz"
@@ -3259,6 +3267,11 @@ next-tick@1, next-tick@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.1.0.tgz#1836ee30ad56d67ef281b22bd199f709449b35eb"
   integrity sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==
+
+node-addon-api@^3.1.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.2.1.tgz#81325e0a2117789c0128dab65e7e38f07ceba161"
+  integrity sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==
 
 node-addon-api@^4.2.0:
   version "4.3.0"


### PR DESCRIPTION
# Integrating JWT Tokens

Take a look at this [boilerplate repo](https://github.com/spencerlepine/jwt-node-express) to set up Node/Express/JWT, with separate servers for authorization and authentication.

## How it works
With the `/register` endpoint on the users service, we POST email/passwords from the form in the client. This will add the user to the database, and the hashed password using `bscrypt`.

Next, they redirect to the login page on the frontend, and enter their credentials. This will `POST /login` with credentials, the API will compare the passwords and validate the request.

After `POST /login`, if successful, the same request will generate the `JWT`, signing with the secret, storing whatever info we need in an object (e.g. email, name, userid). It will then send this back as an `HttpOnly` cookie, which will be saved on the client, inaccessible from javascript. This JWT has a 10min expiration date.

Also, after `POST /login`, it will generate a `JWT` refresh token and pass that along to the client as well. This refresh token should get stored in a database, like Redis Cache.

From here on out, the client can make requests to the backend, and the `Authorization: Bearer jdh8475105...` token will be forwarded with every request by the browser. There is middleware on the backend that will intercept the request, and verify the `JWT` with the `ACCESS_TOKEN_SECRET`. If JWT is not compromised, then we can trust that it is valid data. Whatever data is inside of it, like a `ROLES: ['get_posts', 'delete_posts']`, you can assume its legit because only the server could have previously packed data into the JWT when it was generated + signed.

With the user logged in, they can use the `GET /token` endpoint to generate another refresh token.

With the user logged in, they can use the `DELETE /logout` endpoint to revoke the refresh tokens, and this should also delete the record of refresh token from the Redis cache.

Across the stack, here is how the authentication will work:
1. Client makes `POST /login` request to the Gateway API, with email/password credentials. This request is forwarded to the Users API, which will validate the hashed password in the database, and give back the user a JWT. This JWT is stored in the browser, but was signed by the server, so was generated from a trusted source.

2. Client makes `GET /products/catalog` request to the Gateway API, forward Authorization Token as a header from the HttpOnly cookie stored client-side. The API applies middleware, and forwards a request to `/authenticate` on the Users API. If this is successful, the API then forwards the request to the expected internal microservice.

